### PR TITLE
Php upgrade exploration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Claude Code settings and memory
+.claude/

--- a/Controller/Adminhtml/Event/Export.php
+++ b/Controller/Adminhtml/Event/Export.php
@@ -11,6 +11,16 @@ use Kustomer\WebhookIntegration\Helper\Data;
 class Export extends Action
 {
   /**
+   * @var ResultFactory
+   */
+  protected $_resultFactory;
+
+  /**
+   * @var UrlInterface
+   */
+  protected $_urlBuilder;
+
+  /**
    * @var Data
    */
   protected $_webhookHelper;

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -73,6 +73,16 @@ class Data extends AbstractHelper
    */
   protected $_resourceConnection;
 
+  /**
+   * @var \Psr\Log\LoggerInterface
+   */
+  protected $logger;
+
+  /**
+   * @var EventFactory
+   */
+  protected $eventFactory;
+
   public function __construct(
     Context $context,
     EventFactory $eventFactory,

--- a/Observer/Address.php
+++ b/Observer/Address.php
@@ -8,15 +8,8 @@ use Kustomer\WebhookIntegration\Helper\Data;
 
 class Address implements ObserverInterface
 {
-  /**
-   * @var Data
-   */
-  protected $helper;
+  protected Data $helper;
 
-  /**
-   * Constructor
-   * @param Data $helper
-   */
   public function __construct(Data $helper)
   {
     $this->helper = $helper;

--- a/Observer/Address.php
+++ b/Observer/Address.php
@@ -9,6 +9,11 @@ use Kustomer\WebhookIntegration\Helper\Data;
 class Address implements ObserverInterface
 {
   /**
+   * @var Data
+   */
+  protected $helper;
+
+  /**
    * Constructor
    * @param Data $helper
    */

--- a/Observer/Customer.php
+++ b/Observer/Customer.php
@@ -8,15 +8,8 @@ use Kustomer\WebhookIntegration\Helper\Data;
 
 class Customer implements ObserverInterface
 {
-  /**
-   * @var Data
-   */
-  protected $helper;
+  protected Data $helper;
 
-  /**
-   * Constructor
-   * @param Data $helper
-   */
   public function __construct(Data $helper)
   {
     $this->helper = $helper;

--- a/Observer/Customer.php
+++ b/Observer/Customer.php
@@ -9,6 +9,11 @@ use Kustomer\WebhookIntegration\Helper\Data;
 class Customer implements ObserverInterface
 {
   /**
+   * @var Data
+   */
+  protected $helper;
+
+  /**
    * Constructor
    * @param Data $helper
    */

--- a/Observer/Order.php
+++ b/Observer/Order.php
@@ -9,6 +9,11 @@ use Kustomer\WebhookIntegration\Helper\Data;
 class Order implements ObserverInterface
 {
   /**
+   * @var Data
+   */
+  protected $helper;
+
+  /**
    * Constructor
    * @param Data $helper
    */

--- a/Observer/Order.php
+++ b/Observer/Order.php
@@ -8,15 +8,8 @@ use Kustomer\WebhookIntegration\Helper\Data;
 
 class Order implements ObserverInterface
 {
-  /**
-   * @var Data
-   */
-  protected $helper;
+  protected Data $helper;
 
-  /**
-   * Constructor
-   * @param Data $helper
-   */
   public function __construct(Data $helper)
   {
     $this->helper = $helper;

--- a/Observer/OrderAddress.php
+++ b/Observer/OrderAddress.php
@@ -9,21 +9,10 @@ use Magento\Sales\Api\OrderRepositoryInterface;
 
 class OrderAddress implements ObserverInterface
 {
-  /**
-   * @var Data
-   */
-  protected $helper;
+  protected Data $helper;
 
-  /**
-   * @var OrderRepositoryInterface
-   */
-  protected $_orderRepository;
+  protected OrderRepositoryInterface $_orderRepository;
 
-  /**
-   * Constructor
-   * @param Data $helper
-   * @param OrderRepositoryInterface $orderRepository
-   */
   public function __construct(Data $helper, OrderRepositoryInterface $orderRepository)
   {
     $this->helper = $helper;

--- a/Observer/OrderAddress.php
+++ b/Observer/OrderAddress.php
@@ -10,6 +10,16 @@ use Magento\Sales\Api\OrderRepositoryInterface;
 class OrderAddress implements ObserverInterface
 {
   /**
+   * @var Data
+   */
+  protected $helper;
+
+  /**
+   * @var OrderRepositoryInterface
+   */
+  protected $_orderRepository;
+
+  /**
    * Constructor
    * @param Data $helper
    * @param OrderRepositoryInterface $orderRepository

--- a/PHP_8_UPGRADE_PLAN.md
+++ b/PHP_8_UPGRADE_PLAN.md
@@ -284,7 +284,7 @@ While not breaking in PHP 8.3/8.4, adding return types improves type safety:
 
 ### Refactor ObjectManager Usage (Optional)
 
-`Helper/Data.php` uses `ObjectManager::getInstance()` in 4 places (lines 77-78, 127-128, 147-149, 171-173). This is a Magento anti-pattern but NOT a PHP 8.3/8.4 compatibility issue. Consider refactoring to use proper dependency injection if time permits.
+`Helper/Data.php` uses `ObjectManager::getInstance()` in 4 places (lines 77-78, 127-128, 147-149, 171-173). This is a Magento anti-pattern but NOT a PHP 8.3/8.4 compatibility issue. Consider refactoring to use proper [dependency injection](https://developer.adobe.com/commerce/php/development/components/dependency-injection/) if time permits.
 
 ---
 

--- a/PHP_8_UPGRADE_PLAN.md
+++ b/PHP_8_UPGRADE_PLAN.md
@@ -1,0 +1,269 @@
+# PHP 8.3/8.4 Compatibility Upgrade Plan
+
+## Context
+
+This Adobe Commerce extension (Kustomer Webhook Integration) currently supports only PHP 8.1 and 8.2. The user wants to upgrade it to support PHP 8.3 and 8.4.
+
+**The Problem:**
+PHP 8.2 deprecated dynamic property creation, and PHP 8.3+ throws fatal errors when undeclared properties are assigned. This codebase has 6 files with undeclared properties that will cause immediate runtime failures in PHP 8.3+.
+
+**Impact if not fixed:**
+- Extension will crash on PHP 8.3+ with "Cannot access undeclared property" errors
+- All webhook functionality will break
+- Admin panel features (event log, export, retry) will fail
+
+**The Solution:**
+Fix all undeclared property issues and update composer.json to declare PHP 8.3/8.4 support.
+
+---
+
+## Implementation Steps
+
+### Step 1: Fix Helper/Data.php - Add Missing Property Declarations
+
+**File:** `Helper/Data.php`
+
+**Issue:** Lines 61-62 assign `$this->logger` and `$this->eventFactory` without property declarations.
+
+**Fix:** Add property declarations after line 47 (after `$_orderRepository` declaration):
+
+```php
+/**
+ * @var \Psr\Log\LoggerInterface
+ */
+protected $logger;
+
+/**
+ * @var EventFactory
+ */
+protected $eventFactory;
+```
+
+---
+
+### Step 2: Fix Observer/Order.php - Add Missing Property Declaration
+
+**File:** `Observer/Order.php`
+
+**Issue:** Line 17 assigns `$this->helper` without property declaration.
+
+**Fix:** Add property declaration after line 9 (after class declaration, before constructor):
+
+```php
+/**
+ * @var Data
+ */
+protected $helper;
+```
+
+---
+
+### Step 3: Fix Observer/Customer.php - Add Missing Property Declaration
+
+**File:** `Observer/Customer.php`
+
+**Issue:** Constructor assigns `$this->helper` without property declaration.
+
+**Fix:** Add property declaration after line 9 (after class declaration):
+
+```php
+/**
+ * @var Data
+ */
+protected $helper;
+```
+
+---
+
+### Step 4: Fix Observer/Address.php - Add Missing Property Declaration
+
+**File:** `Observer/Address.php`
+
+**Issue:** Constructor assigns `$this->helper` without property declaration.
+
+**Fix:** Add property declaration after line 9 (after class declaration):
+
+```php
+/**
+ * @var Data
+ */
+protected $helper;
+```
+
+---
+
+### Step 5: Fix Observer/OrderAddress.php - Add Missing Property Declarations
+
+**File:** `Observer/OrderAddress.php`
+
+**Issue:** Lines 19-20 assign `$this->helper` and `$this->_orderRepository` without property declarations.
+
+**Fix:** Add property declarations after line 10 (after class declaration, before constructor):
+
+```php
+/**
+ * @var Data
+ */
+protected $helper;
+
+/**
+ * @var OrderRepositoryInterface
+ */
+protected $_orderRepository;
+```
+
+---
+
+### Step 6: Fix Controller/Adminhtml/Event/Export.php - Add Missing Property Declarations
+
+**File:** `Controller/Adminhtml/Event/Export.php`
+
+**Issue:** Lines 24 and 26 assign `$this->_resultFactory` and `$this->_urlBuilder` without property declarations. Only `$_webhookHelper` is declared (line 16).
+
+**Fix:** Add property declarations after line 12 (before the existing `$_webhookHelper` declaration):
+
+```php
+/**
+ * @var ResultFactory
+ */
+protected $_resultFactory;
+
+/**
+ * @var UrlInterface
+ */
+protected $_urlBuilder;
+```
+
+---
+
+### Step 7: Update composer.json - Add PHP 8.3/8.4 Support
+
+**File:** `composer.json`
+
+**Current:** Line 8 has `"php": "~8.1.0|~8.2.0"`
+
+**Fix:** Update to support PHP 8.3 and 8.4:
+
+```json
+"php": "~8.1.0|~8.2.0|~8.3.0|~8.4.0"
+```
+
+**Alternative (recommended):** Use caret constraint for automatic future support:
+
+```json
+"php": "^8.1"
+```
+
+This automatically includes 8.1, 8.2, 8.3, 8.4, and future 8.x versions.
+
+---
+
+## Critical Files to Modify
+
+1. `Helper/Data.php` - Add 2 property declarations
+2. `Observer/Order.php` - Add 1 property declaration
+3. `Observer/Customer.php` - Add 1 property declaration
+4. `Observer/Address.php` - Add 1 property declaration
+5. `Observer/OrderAddress.php` - Add 2 property declarations
+6. `Controller/Adminhtml/Event/Export.php` - Add 2 property declarations
+7. `composer.json` - Update PHP version constraint
+
+**Total:** 7 files, 10 property declarations + 1 composer.json update
+
+---
+
+## Verification Steps
+
+After making all changes, verify compatibility:
+
+### 1. Check Syntax (PHP 8.3/8.4)
+
+If you have PHP 8.3 or 8.4 installed locally:
+
+```bash
+# Check each PHP file for syntax errors
+php -l Helper/Data.php
+php -l Observer/*.php
+php -l Controller/Adminhtml/Event/*.php
+```
+
+### 2. Validate Composer
+
+```bash
+composer validate
+composer install --dry-run
+```
+
+### 3. Deploy to Test Environment
+
+Deploy to a Magento instance running PHP 8.3 or 8.4 and test:
+
+- **Observer Events:** Trigger each observer to ensure no property errors:
+  - Create/edit a customer → triggers `Observer/Customer.php`
+  - Create/edit a customer address → triggers `Observer/Address.php`
+  - Create/edit an order → triggers `Observer/Order.php`
+  - Update order address in admin → triggers `Observer/OrderAddress.php`
+
+- **Admin Panel Features:**
+  - Access Kustomer → Event Logs
+  - Test "Export to JSON" button → uses `Controller/Adminhtml/Event/Export.php`
+  - Test "Retry" button on an event → uses `Helper/Data.php` retry logic
+
+- **Monitor PHP Error Logs:**
+  ```bash
+  tail -f var/log/system.log
+  tail -f var/log/exception.log
+  ```
+  Watch for any dynamic property warnings or errors.
+
+### 4. Check for Deprecation Warnings
+
+Enable error reporting in PHP to catch any remaining issues:
+
+```php
+// In index.php or your test script:
+error_reporting(E_ALL);
+ini_set('display_errors', 1);
+```
+
+Run through all functionality and check for warnings.
+
+---
+
+## Optional: Additional Quality Improvements
+
+These are **not required** for PHP 8.3/8.4 compatibility but improve code quality:
+
+### Add Return Type Declarations
+
+While not breaking in PHP 8.3/8.4, adding return types improves type safety:
+
+- `Helper/Data.php`: Add return types to all methods (`:void`, `:string`, `:array`, etc.)
+- All Observer `execute()` methods should return `:void`
+- All Controller `execute()` methods should return `:\Magento\Framework\Controller\ResultInterface` or specific type
+
+### Refactor ObjectManager Usage (Optional)
+
+`Helper/Data.php` uses `ObjectManager::getInstance()` in 4 places (lines 77-78, 127-128, 147-149, 171-173). This is a Magento anti-pattern but NOT a PHP 8.3/8.4 compatibility issue. Consider refactoring to use proper dependency injection if time permits.
+
+---
+
+## Risk Assessment
+
+- **Risk Level:** Low (changes are straightforward property declarations)
+- **Breaking Changes:** None (only adds missing declarations, doesn't change logic)
+- **Backwards Compatible:** Yes (PHP 8.1/8.2 still supported)
+- **Testing Required:** Medium (manual testing of all webhook events recommended)
+
+---
+
+## Success Criteria
+
+✅ All property declarations added
+✅ composer.json updated to support PHP 8.3/8.4
+✅ No PHP syntax errors when checked with PHP 8.3/8.4
+✅ `composer validate` passes
+✅ All observer events trigger without errors
+✅ Admin panel export and retry features work
+✅ No deprecation warnings in error logs
+✅ Extension deploys successfully on PHP 8.3/8.4 environment

--- a/PHP_8_UPGRADE_PLAN.md
+++ b/PHP_8_UPGRADE_PLAN.md
@@ -1,5 +1,45 @@
 # PHP 8.3/8.4 Compatibility Upgrade Plan
 
+## ✅ Implementation Status
+
+**Status:** COMPLETED (2026-02-06)
+
+All code changes have been successfully implemented and validated. The extension now supports PHP 8.1, 8.2, 8.3, 8.4, and future 8.x versions.
+
+### What Was Completed:
+
+✅ **Step 1:** Helper/Data.php - Added 2 property declarations (`$logger`, `$eventFactory`)
+✅ **Step 2:** Observer/Order.php - Added 1 property declaration (`$helper`)
+✅ **Step 3:** Observer/Customer.php - Added 1 property declaration (`$helper`)
+✅ **Step 4:** Observer/Address.php - Added 1 property declaration (`$helper`)
+✅ **Step 5:** Observer/OrderAddress.php - Added 2 property declarations (`$helper`, `$_orderRepository`)
+✅ **Step 6:** Controller/Adminhtml/Event/Export.php - Added 2 property declarations (`$_resultFactory`, `$_urlBuilder`)
+✅ **Step 7:** composer.json - Updated PHP requirement to `^8.1` (supports 8.1, 8.2, 8.3, 8.4+)
+✅ **Validation:** All files validated with PHP 8.5.2 - no syntax errors detected
+
+**Total Changes:** 7 files modified, 10 property declarations added
+
+**Files Modified:**
+- `Helper/Data.php` (lines 49-57)
+- `Observer/Order.php` (lines 11-14)
+- `Observer/Customer.php` (lines 11-14)
+- `Observer/Address.php` (lines 11-14)
+- `Observer/OrderAddress.php` (lines 12-19)
+- `Controller/Adminhtml/Event/Export.php` (lines 13-20)
+- `composer.json` (line 8)
+
+### What's Next:
+
+The following verification steps should be completed in a test environment:
+
+1. ⏳ Deploy to Magento test environment with PHP 8.3 or 8.4
+2. ⏳ Test all webhook functionality (customer, address, order events)
+3. ⏳ Test admin panel features (Event Logs, Export, Retry)
+4. ⏳ Monitor error logs for any remaining issues
+5. ⏳ Deploy to production once testing is complete
+
+---
+
 ## Context
 
 This Adobe Commerce extension (Kustomer Webhook Integration) currently supports only PHP 8.1 and 8.2. The user wants to upgrade it to support PHP 8.3 and 8.4.
@@ -259,11 +299,47 @@ While not breaking in PHP 8.3/8.4, adding return types improves type safety:
 
 ## Success Criteria
 
-✅ All property declarations added
-✅ composer.json updated to support PHP 8.3/8.4
-✅ No PHP syntax errors when checked with PHP 8.3/8.4
-✅ `composer validate` passes
-✅ All observer events trigger without errors
-✅ Admin panel export and retry features work
-✅ No deprecation warnings in error logs
-✅ Extension deploys successfully on PHP 8.3/8.4 environment
+### Completed ✅
+
+✅ All property declarations added (10 total across 6 files)
+✅ composer.json updated to support PHP 8.3/8.4 (using `^8.1`)
+✅ No PHP syntax errors when checked with PHP 8.5.2
+✅ All files validated successfully
+
+### Pending Testing ⏳
+
+⏳ `composer validate` passes (requires composer installation)
+⏳ All observer events trigger without errors (requires test environment)
+⏳ Admin panel export and retry features work (requires test environment)
+⏳ No deprecation warnings in error logs (requires test environment)
+⏳ Extension deploys successfully on PHP 8.3/8.4 environment
+
+---
+
+## Next Steps for Deployment
+
+1. **Install in Test Environment:**
+   ```bash
+   # Deploy extension to Magento test instance with PHP 8.3 or 8.4
+   php bin/magento module:enable Kustomer_WebhookIntegration
+   php bin/magento setup:upgrade
+   php bin/magento cache:flush
+   ```
+
+2. **Run Functional Tests:**
+   - Create/edit a customer (tests `Observer/Customer.php`)
+   - Create/edit a customer address (tests `Observer/Address.php`)
+   - Create/edit an order (tests `Observer/Order.php`)
+   - Update order address in admin (tests `Observer/OrderAddress.php`)
+   - Export event logs to JSON (tests `Controller/Adminhtml/Event/Export.php`)
+   - Retry a failed event (tests `Helper/Data.php`)
+
+3. **Monitor for Issues:**
+   ```bash
+   tail -f var/log/system.log
+   tail -f var/log/exception.log
+   # Watch for any dynamic property errors or deprecation warnings
+   ```
+
+4. **Deploy to Production:**
+   Once all tests pass in the test environment, deploy to production using your standard deployment process.

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "version": "1.0.0",
   "license": [],
   "require": {
-    "php": "~8.1.0|~8.2.0"
+    "php": "^8.1"
   },
   "autoload": {
     "files": [

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "version": "1.0.0",
   "license": [],
   "require": {
-    "php": "^8.1 <8.5"
+    "php": "^8.1"
   },
   "autoload": {
     "files": [

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "version": "1.0.0",
   "license": [],
   "require": {
-    "php": "^8.1"
+    "php": "^8.1 <8.5"
   },
   "autoload": {
     "files": [


### PR DESCRIPTION
# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Address dynamic property declarations in the webhook helper, webhook observers, and admin export controller to keep their dependencies defined under PHP 8.3/8.4 runtime rules. Raise the platform constraint and document the PHP upgrade plan plus tool ignores to reinforce compatibility and rollout guidance for the extension.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/kustomer/adobe_commerce_extension/7?tool=ast&topic=Observer+dependencies>Observer dependencies</a>
        </td><td>Declare the missing helper, observer, and export controller properties so dependency wiring survives PHP 8.3+ dynamic property enforcement across webhook observers, helper utilities, and the admin export flow.<details><summary>Modified files (6)</summary><ul><li>Controller/Adminhtml/Event/Export.php</li>
<li>Helper/Data.php</li>
<li>Observer/Address.php</li>
<li>Observer/Customer.php</li>
<li>Observer/Order.php</li>
<li>Observer/OrderAddress.php</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>brian.hong@kustomer.com</td><td>Address CodeRabbit nit...</td><td>May 13, 2026</td></tr>
<tr><td>brianhong@users.norepl...</td><td>PROD-98 PR 3/4: state-...</td><td>May 13, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/kustomer/adobe_commerce_extension/7?tool=ast&topic=Upgrade+doc+%26+tooling>Upgrade doc & tooling</a>
        </td><td>Document the PHP 8.x upgrade plan and ignore the Claude settings directory so the new compatibility work and tooling artifacts stay transparent for reviewers.<details><summary>Modified files (2)</summary><ul><li>.gitignore</li>
<li>PHP_8_UPGRADE_PLAN.md</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>brian.hong@kustomer.com</td><td>Address CodeRabbit nit...</td><td>May 13, 2026</td></tr>
<tr><td>john.royall@kustomer.com</td><td>gitignore .claude</td><td>February 06, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/kustomer/adobe_commerce_extension/7?tool=ast&topic=PHP+platform+bump>PHP platform bump</a>
        </td><td>Bump the composer PHP requirement to <code>^8.1</code> to signal and enforce compatibility through PHP 8.4 and future 8.x releases for the webhook integration.<details><summary>Modified files (1)</summary><ul><li>composer.json</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>brian.hong@kustomer.com</td><td>Drop <8.5 PHP cap to m...</td><td>May 13, 2026</td></tr>
<tr><td>john.royall@kustomer.com</td><td>claude implements the ...</td><td>February 06, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/kustomer/adobe_commerce_extension/7?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>