### PR TITLE
EUX-1995: Add cURL timeouts to Adobe Commerce extension requests

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -229,17 +229,29 @@ class Data extends AbstractHelper
       ],
     ]);
 
-    // Submit the request
-    $response = curl_exec($curl);
-    $statusCode = curl_getinfo($curl, CURLINFO_HTTP_CODE);
+    try {
+      // Submit the request
+      $response = curl_exec($curl);
 
-    // If there's an error, log and throw an exception
-    if ($statusCode !== 200) {
-      throw new \Exception($response);
+      // curl_exec returns false on failure (including timeouts)
+      if ($response === false) {
+        throw new \Exception(sprintf(
+          'cURL error (%d): %s',
+          curl_errno($curl),
+          curl_error($curl)
+        ));
+      }
+
+      $statusCode = (int) curl_getinfo($curl, CURLINFO_HTTP_CODE);
+
+      // If there's an error, log and throw an exception
+      if ($statusCode !== 200) {
+        throw new \Exception(sprintf('HTTP %d: %s', $statusCode, $response));
+      }
+    } finally {
+      // Always close the cURL session handle
+      curl_close($curl);
     }
-
-    // Close cURL session handle
-    curl_close($curl);
 
     // Return the response
     return json_decode($response, true);

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -216,6 +216,8 @@ class Data extends AbstractHelper
       CURLOPT_RETURNTRANSFER => true,
       CURLOPT_CUSTOMREQUEST => 'POST',
       CURLOPT_POSTFIELDS => $encodedPayload,
+      CURLOPT_CONNECTTIMEOUT_MS => 3000,
+      CURLOPT_TIMEOUT_MS => 10000,
       CURLOPT_HTTPHEADER => [
         'Accept: application/json',
         'Token: ' . $hashedToken,


### PR DESCRIPTION
# User description
## Problem

The Adobe Commerce extension sends webhook events to Kustomer synchronously — directly within the PHP observer that fires during storefront actions like checkout, customer save, and order save. This means the PHP-FPM worker handling the commerce action is blocked until Kustomer returns a response.

Under load, the Kustomer adobe-commerce server can become a bottleneck, causing the app-gateway to return `504 Gateway Timeout` responses after its 30-second timeout. Without any timeout configured in the extension, PHP workers wait the full 30–60+ seconds for the 504 — or indefinitely if the connection never establishes. When enough workers accumulate in this state, the PHP-FPM pool is exhausted and the storefront enters a maintenance state.

This was the root cause of the production incident reported in PLA-1355 (August / The Master Lock Company). Assaabloy has separately raised the same concern.

## Why this repo

The Adobe Commerce integration is split across two codebases:

- **`internal-apps/adobe-commerce/packages/server`** — the Kustomer-side Node.js app that receives webhook events, calls back to Adobe Commerce's REST API, and writes data into Kustomer
- **`internal-apps/adobe-commerce/packages/extension`** — a Docker environment for running a local Adobe Commerce instance during development. The actual PHP source is gitignored here; the README explicitly states the canonical source lives in this repo (`kustomer/adobe_commerce_extension`)

This repo is what gets installed on customer Adobe Commerce stores via Packagist. It is the code running in production at affected customers. The fix belongs here.

## Solution

Added two cURL timeout options to `sendApiRequest()` in `Helper/Data.php`:

- **`CURLOPT_CONNECTTIMEOUT_MS 3000`** — caps the DNS resolution + TCP handshake phase. Without this, a misconfigured DNS entry or unreachable host can stall indefinitely regardless of the read timeout.
- **`CURLOPT_TIMEOUT_MS 10000`** — caps the total request duration (connect + send + receive). If Kustomer hasn't responded within 10 seconds, the request is abandoned.

When a timeout fires, it throws a cURL exception which is caught by the existing `catch (\Exception $e)` block in `send()` and `retry()`. The failure is logged to `var/log/exception.log` and persisted to the Adobe Commerce event log with a failed status, where it can be manually retried from the admin panel.

This does not prevent 504s from occurring — that is addressed separately in EUX-1792 (async processing on the Kustomer server side). This fix ensures PHP workers are freed quickly regardless of what Kustomer does, protecting the storefront from resource exhaustion.

## Testing plan

We have an existing staging Adobe Commerce store already connected to a Kustomer staging account, which makes this straightforward to validate without any local setup.

Local setup for this repo is not practical for a change of this scope. It requires running a full Adobe Commerce Docker stack, obtaining GitHub Codespaces access (a prerequisite flagged internally as taking ~1 week to arrange), and completing an OAuth integration flow between the local store and a Kustomer environment. A [team member who went through this process](https://kustomer.slack.com/archives/C08AMJD1BJA/p1776776451824369?thread_ts=1776775728.481709&cid=C08AMJD1BJA) noted it was not worth the time and recommended testing on staging instead — which we have available.

We can simulate a slow/unresponsive Kustomer endpoint directly in the Adobe Commerce admin panel by temporarily pointing the integration's Identity Link URL at a delay service. The `getWebhookUrl()` method derives the outbound webhook URL from this field at request time, so no code changes or redeployment are needed to switch targets.

1. **Baseline (pre-merge):** set the Identity Link URL to a 15-second delay endpoint, trigger a commerce event, observe the PHP worker hanging for ~75 seconds before completing.
2. **Post-merge:** same setup, same event — worker should complete after ~10 seconds with a timeout error surfaced in the Adobe Commerce event log.
3. **Happy path:** restore the Identity Link URL to the real Kustomer staging endpoint, trigger an event, confirm it arrives correctly in Kustomer.

## Related

- EUX-1995
- PLA-1355 (originating incident)
- EUX-1792 (server-side async follow-up)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Add connection and total timeouts to <code>Helper/Data::sendApiRequest</code> so the extension stops waiting on Kustomer and frees PHP workers sooner. Ensure its request flow now throws on <code>curl_exec</code> failures and always closes the cURL handle so logging and retry logic keep working when the gateway fails.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>brian.hong@kustomer.com</td><td>Address CodeRabbit rev...</td><td>May 05, 2026</td></tr>
<tr><td>oscar.brennwald@kustom...</td><td>first commit</td><td>August 28, 2023</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/kustomer/adobe_commerce_extension/8?tool=ast>(Baz)</a>.