### PR TITLE
Fix getExtensionVersion() path for Composer installs

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -154,10 +154,7 @@ class Data extends AbstractHelper
    */
   private function getExtensionVersion()
   {
-    $composerJson = file_get_contents(
-      $this->_directoryList->getPath('app') .
-        '/code/Kustomer/WebhookIntegration/composer.json'
-    );
+    $composerJson = file_get_contents(__DIR__ . '/../composer.json');
     $composerJson = json_decode($composerJson, true);
 
     return $composerJson['version'];


### PR DESCRIPTION
## What

Replace the hardcoded \`app/code/Kustomer/WebhookIntegration/composer.json\` path in \`getExtensionVersion()\` with \`__DIR__ . '/../composer.json'\`.

## Why

The previous path assumes the extension is installed manually under \`app/code/\`, which breaks when the extension is installed via Composer (where it lives under \`vendor/kustomer/webhook-integration/\`). This caused a PHP warning during staging testing:

\`\`\`
Warning: file_get_contents(...app/code/Kustomer/WebhookIntegration/composer.json): Failed to open stream: No such file or directory
\`\`\`

Using \`__DIR__\` resolves correctly regardless of install method.

## Context

Our installation guide (https://www.mageplaza.com/install-magento-2-extension/#solution-2-Install-Magento-2-extension-via-Composer) directs users to install via Composer, meaning the extension lands in \`vendor/\` — not \`app/code/\`. The hardcoded path was therefore broken for all users following our recommended installation method.

## Related

Follow-up to #8 (EUX-1995 cURL timeouts), discovered during staging validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)