### PR TITLE
PROD-98 PR 3/4: state-machine helpers and dormant cron consumer

### DIFF
--- a/Cron/ProcessQueue.php
+++ b/Cron/ProcessQueue.php
@@ -103,11 +103,15 @@ class ProcessQueue
    */
   private function recoverExpiredLeases($connection, string $tableName): void
   {
+    // Bounded to BATCH_SIZE so a deploy-induced burst of orphaned rows can't
+    // chew through the cron tick before any new work is claimed. Remaining
+    // orphans are picked up by subsequent ticks.
     $expiredRows = $connection->fetchAll(
       $connection->select()
         ->from($tableName, ['event_id', 'locked_by'])
         ->where('state = ?', 'processing')
         ->where('locked_until <= NOW()')
+        ->limit(self::BATCH_SIZE)
     );
 
     foreach ($expiredRows as $row) {

--- a/Cron/ProcessQueue.php
+++ b/Cron/ProcessQueue.php
@@ -180,10 +180,13 @@ LIMIT :batch_size";
    */
   private function processRow($connection, string $tableName, int $eventId, string $workerId): void
   {
+    $errorMsg = null;
     try {
-      $success = $this->helper->deliverEvent($eventId, $workerId);
+      // deliverEvent returns null on success, otherwise a truncated error
+      // message that we persist verbatim so the admin grid / export carries
+      // the real cURL/HTTP reason (parity with the legacy synchronous path).
+      $errorMsg = $this->helper->deliverEvent($eventId, $workerId);
     } catch (\Throwable $t) {
-      $success = false;
       $errorMsg = substr($t->getMessage(), 0, 200);
       $this->logger->error('Kustomer cron: unexpected exception in deliverEvent', [
         'event_id'    => $eventId,
@@ -191,6 +194,7 @@ LIMIT :batch_size";
         'error'       => $errorMsg,
       ]);
     }
+    $success = $errorMsg === null;
 
     if ($success) {
       // Conditional UPDATE: only write if we still own the lock.
@@ -220,9 +224,6 @@ WHERE `event_id` = :event_id
         ]);
       }
     } else {
-      // Resolve the error string from deliverEvent's structured log or use a placeholder.
-      $errorMsg = 'delivery failed';
-
       $updated = $this->helper->recordFailedAttempt(
         $eventId,
         $errorMsg,

--- a/Cron/ProcessQueue.php
+++ b/Cron/ProcessQueue.php
@@ -1,0 +1,237 @@
+<?php
+
+namespace Kustomer\WebhookIntegration\Cron;
+
+use Kustomer\WebhookIntegration\Helper\Data as WebhookHelper;
+use Magento\Framework\App\ResourceConnection;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Cron consumer that processes the async webhook delivery queue.
+ *
+ * Runs every minute (see etc/crontab.xml). On a queue with zero pending rows
+ * this class exits immediately without side effects, so it is safe to deploy
+ * before send() is flipped to enqueue mode (PR 4).
+ *
+ * Concurrency model
+ * -----------------
+ * Multiple cron workers (multi-node or overlapping runs) are safe because
+ * the claim step is a single atomic UPDATE filtered by state and next_attempt_at.
+ * Each worker generates a unique $workerId per execution; subsequent UPDATEs
+ * require locked_by = $workerId so a stale worker can never overwrite a row
+ * that another worker has already reclaimed.
+ */
+class ProcessQueue
+{
+  /**
+   * Number of rows each cron run claims and processes in one batch.
+   */
+  const BATCH_SIZE = 10;
+
+  /**
+   * @var WebhookHelper
+   */
+  private $helper;
+
+  /**
+   * @var ResourceConnection
+   */
+  private $resourceConnection;
+
+  /**
+   * @var LoggerInterface
+   */
+  private $logger;
+
+  public function __construct(
+    WebhookHelper $helper,
+    ResourceConnection $resourceConnection,
+    LoggerInterface $logger
+  ) {
+    $this->helper             = $helper;
+    $this->resourceConnection = $resourceConnection;
+    $this->logger             = $logger;
+  }
+
+  /**
+   * Main entry point, called by the Magento cron scheduler every minute.
+   *
+   * @return void
+   */
+  public function execute(): void
+  {
+    $workerId  = bin2hex(random_bytes(16));
+    $connection = $this->resourceConnection->getConnection();
+    $tableName  = $this->resourceConnection->getTableName('kustomer_webhook_integration_events');
+
+    // ------------------------------------------------------------------
+    // Step 1: Recover rows whose lease expired (crashed worker recovery).
+    // ------------------------------------------------------------------
+    $this->recoverExpiredLeases($connection, $tableName);
+
+    // ------------------------------------------------------------------
+    // Step 2: Atomically claim a batch of pending / retryable rows.
+    // ------------------------------------------------------------------
+    $claimedIds = $this->claimBatch($connection, $tableName, $workerId);
+
+    if (empty($claimedIds)) {
+      return;
+    }
+
+    $this->logger->info('Kustomer cron: processing batch', [
+      'worker_id' => $workerId,
+      'count'     => count($claimedIds),
+    ]);
+
+    // ------------------------------------------------------------------
+    // Step 3: Deliver each claimed row and record the outcome.
+    // ------------------------------------------------------------------
+    foreach ($claimedIds as $eventId) {
+      $this->processRow($connection, $tableName, (int)$eventId, $workerId);
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // Private helpers
+  // -----------------------------------------------------------------------
+
+  /**
+   * Find all rows that are still in state='processing' but whose lease has
+   * expired (crashed-worker recovery).  For each, call recordFailedAttempt
+   * with requireExpiredLease=true so a concurrent worker cannot steal
+   * a row whose lease is still valid.
+   */
+  private function recoverExpiredLeases($connection, string $tableName): void
+  {
+    $expiredRows = $connection->fetchAll(
+      $connection->select()
+        ->from($tableName, ['event_id', 'locked_by'])
+        ->where('state = ?', 'processing')
+        ->where('locked_until <= NOW()')
+    );
+
+    foreach ($expiredRows as $row) {
+      $updated = $this->helper->recordFailedAttempt(
+        (int)$row['event_id'],
+        'lease expired',
+        (string)$row['locked_by'],
+        true  // requireExpiredLease
+      );
+
+      if (!$updated) {
+        // Another concurrent worker already handled this row — that is fine.
+        $this->logger->info('Kustomer cron: expired-lease row already recovered by another worker', [
+          'event_id' => $row['event_id'],
+        ]);
+      }
+    }
+  }
+
+  /**
+   * Claim up to BATCH_SIZE rows with a single atomic UPDATE, then SELECT
+   * back the claimed event IDs.
+   *
+   * MySQL note: INTERVAL N MINUTE without quotes — Postgres-style
+   * INTERVAL '5 MINUTE' is intentionally avoided.
+   *
+   * @return int[]
+   */
+  private function claimBatch($connection, string $tableName, string $workerId): array
+  {
+    // Atomic claim: transition pending/retryable rows to processing.
+    // Mirrors o-webhooks-worker convention: retryable failures share the
+    // 'failed' state with terminal failures, distinguished by next_attempt_at.
+    // The IS NOT NULL + <= NOW() predicate excludes terminal failures
+    // (next_attempt_at IS NULL) naturally.
+    $claimSql = "UPDATE `{$tableName}`
+SET
+    `state`        = 'processing',
+    `status`       = 0,
+    `locked_until` = DATE_ADD(NOW(), INTERVAL 5 MINUTE),
+    `locked_by`    = :worker_id
+WHERE `state` IN ('pending', 'failed')
+  AND `next_attempt_at` IS NOT NULL
+  AND `next_attempt_at` <= NOW()
+ORDER BY `created_at` ASC
+LIMIT :batch_size";
+
+    $connection->query($claimSql, [
+      'worker_id'  => $workerId,
+      'batch_size' => self::BATCH_SIZE,
+    ]);
+
+    // Read back the rows we just claimed.
+    $rows = $connection->fetchAll(
+      $connection->select()
+        ->from($tableName, ['event_id'])
+        ->where('state = ?', 'processing')
+        ->where('locked_by = ?', $workerId)
+    );
+
+    return array_column($rows, 'event_id');
+  }
+
+  /**
+   * Attempt delivery for a single claimed row and write the outcome.
+   */
+  private function processRow($connection, string $tableName, int $eventId, string $workerId): void
+  {
+    try {
+      $success = $this->helper->deliverEvent($eventId, $workerId);
+    } catch (\Throwable $t) {
+      $success = false;
+      $errorMsg = substr($t->getMessage(), 0, 200);
+      $this->logger->error('Kustomer cron: unexpected exception in deliverEvent', [
+        'event_id'    => $eventId,
+        'error_class' => get_class($t),
+        'error'       => $errorMsg,
+      ]);
+    }
+
+    if ($success) {
+      // Conditional UPDATE: only write if we still own the lock.
+      $successSql = "UPDATE `{$tableName}`
+SET
+    `state`           = 'succeeded',
+    `status`          = 1,
+    `locked_by`       = NULL,
+    `locked_until`    = NULL,
+    `next_attempt_at` = NULL,
+    `last_sent_at`    = NOW(),
+    `error`           = NULL
+WHERE `event_id` = :event_id
+  AND `state`    = 'processing'
+  AND `locked_by`= :worker_id";
+
+      $stmt     = $connection->query($successSql, [
+        'event_id'  => $eventId,
+        'worker_id' => $workerId,
+      ]);
+      $affected = $stmt->rowCount();
+
+      if ($affected === 0) {
+        $this->logger->warning('Kustomer cron: success UPDATE matched 0 rows (stale worker)', [
+          'event_id'  => $eventId,
+          'worker_id' => $workerId,
+        ]);
+      }
+    } else {
+      // Resolve the error string from deliverEvent's structured log or use a placeholder.
+      $errorMsg = 'delivery failed';
+
+      $updated = $this->helper->recordFailedAttempt(
+        $eventId,
+        $errorMsg,
+        $workerId,
+        false  // requireExpiredLease
+      );
+
+      if (!$updated) {
+        $this->logger->warning('Kustomer cron: failure transition matched 0 rows (stale worker)', [
+          'event_id'  => $eventId,
+          'worker_id' => $workerId,
+        ]);
+      }
+    }
+  }
+}

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -17,15 +17,21 @@ use Magento\Sales\Api\OrderRepositoryInterface;
 class Data extends AbstractHelper
 {
   /**
-   * Maximum number of delivery attempts before a row transitions to terminal_failed.
-   * Attempt 1 sets retry_count=1, ..., attempt MAX_RETRIES sets retry_count=MAX_RETRIES
-   * which triggers terminal_failed on the next recordFailedAttempt call.
+   * Number of retries permitted after the initial delivery attempt. With
+   * MAX_RETRIES=4 a row is attempted up to 5 times (initial + 4 retries):
+   *   attempt 1 (retry_count=0 -> 1, schedule using ladder[0] = 60s)
+   *   attempt 2 (retry_count=1 -> 2, schedule using ladder[1] = 300s)
+   *   attempt 3 (retry_count=2 -> 3, schedule using ladder[2] = 1800s)
+   *   attempt 4 (retry_count=3 -> 4, schedule using ladder[3] = 7200s)
+   *   attempt 5 (retry_count=4 -> 5, terminal: next_attempt_at = NULL)
+   * Terminal transition fires when newRetryCount > MAX_RETRIES.
    */
   const MAX_RETRIES = 4;
 
   /**
-   * Backoff ladder in seconds, indexed by new retry_count after increment.
-   * [1m, 5m, 30m, 2h]. Out-of-range index clamps to last value.
+   * Backoff ladder in seconds, indexed by (newRetryCount - 1) so the first
+   * retry uses 60s. Entries: 1m, 5m, 30m, 2h. Out-of-range index clamps to
+   * the last value (defensive — should not happen given the terminal guard).
    */
   private static $backoffLadder = [60, 300, 1800, 7200];
 
@@ -305,21 +311,20 @@ class Data extends AbstractHelper
    */
   public function enqueue(array $payload): void
   {
+    // Precondition check runs OUTSIDE the try/catch so a buggy caller surfaces
+    // as a real exception instead of being silently routed to the fail-open
+    // log. store_id is a NOT NULL FK to store.store_id; passing an unset/zero
+    // value is a programmer error, not a runtime DB failure.
+    $storeId = (int) ($payload['event']['store']['id'] ?? 0);
+    if ($storeId <= 0) {
+      throw new \InvalidArgumentException(
+        'enqueue: payload missing event.store.id; caller must populate store data'
+      );
+    }
+
     try {
       $connection = $this->_resourceConnection->getConnection();
       $tableName  = $this->_resourceConnection->getTableName('kustomer_webhook_integration_events');
-
-      // Precondition: caller must populate $payload['event']['store'] via
-      // getStoreData() before enqueue (mirrors today's send() behavior).
-      // store_id is a NOT NULL FK to store.store_id; an unset/zero value
-      // would surface as an FK violation and silently route to the
-      // fail-open log. Fail loudly here so the bug is in the caller.
-      $storeId = (int) ($payload['event']['store']['id'] ?? 0);
-      if ($storeId <= 0) {
-        throw new \InvalidArgumentException(
-          'enqueue: payload missing event.store.id; caller must populate store data'
-        );
-      }
 
       $connection->insert($tableName, [
         'store_id'       => $storeId,
@@ -463,8 +468,10 @@ class Data extends AbstractHelper
       'locked_until'=> null,
     ];
 
-    if ($newRetryCount >= self::MAX_RETRIES) {
+    if ($newRetryCount > self::MAX_RETRIES) {
       // Terminal: NULL next_attempt_at signals "won't retry."
+      // newRetryCount==MAX_RETRIES is still retryable (uses ladder's last
+      // entry) — terminal only fires once retries are exhausted.
       $data['next_attempt_at'] = null;
     } else {
       // Retryable: schedule next attempt per the backoff ladder.

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -326,9 +326,20 @@ class Data extends AbstractHelper
       $connection = $this->_resourceConnection->getConnection();
       $tableName  = $this->_resourceConnection->getTableName('kustomer_webhook_integration_events');
 
+      // JSON_THROW_ON_ERROR turns malformed UTF-8 / recursive payloads into
+      // a thrown JsonException instead of a silent `false` return — without
+      // it the row would persist with payload='' or 'false' and become an
+      // undecodable dead letter that deliverEvent re-fails every retry tick.
+      // The throw is caught by the outer try/catch and goes through the
+      // fail-open log path, same as any other INSERT-time failure.
+      $encodedPayload = json_encode(
+        $payload,
+        JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR
+      );
+
       $connection->insert($tableName, [
         'store_id'       => $storeId,
-        'payload'        => json_encode($payload, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE),
+        'payload'        => $encodedPayload,
         'status'         => 0,
         'uri'            => $this->getWebhookUrl(),
         'state'          => 'pending',
@@ -367,7 +378,8 @@ class Data extends AbstractHelper
    * Does NOT touch any state column — that is the caller's responsibility.
    *
    * @param int    $eventId
-   * @param string $workerId  (unused by HTTP layer, reserved for future tracing)
+   * @param string $workerId  Caller's lease owner; row is only delivered if
+   *                          this worker still owns an unexpired lease.
    * @return string|null  null on HTTP 200; otherwise a truncated error message
    *                      that the caller should persist via recordFailedAttempt.
    */
@@ -376,13 +388,32 @@ class Data extends AbstractHelper
     $connection = $this->_resourceConnection->getConnection();
     $tableName  = $this->_resourceConnection->getTableName('kustomer_webhook_integration_events');
 
+    // Verify lease ownership before any external side effect. Without this
+    // check, a worker whose lease has already expired and been recovered by
+    // another worker would still perform the HTTP POST, producing a duplicate
+    // delivery whose DB-side update is later rejected by the conditional
+    // UPDATE — visible to the caller as a logged warning, but invisible to
+    // Kustomer, which has already received the redundant webhook.
+    //
+    // The window cannot be eliminated entirely (the lease can expire between
+    // this SELECT and the cURL completion), but the check shrinks it from
+    // "the entire claim → cURL latency" to "the SELECT → cURL gap." Kustomer
+    // idempotency on stable externalId is still the load-bearing safety net.
     $row = $connection->fetchRow(
-      $connection->select()->from($tableName)->where('event_id = ?', $eventId)
+      $connection->select()
+        ->from($tableName)
+        ->where('event_id = ?', $eventId)
+        ->where('state = ?', 'processing')
+        ->where('locked_by = ?', $workerId)
+        ->where('locked_until > NOW()')
     );
 
     if (!$row) {
-      $this->logger->error('deliverEvent: event row not found', ['event_id' => $eventId]);
-      return 'event row not found';
+      $this->logger->warning('deliverEvent: lease no longer owned, skipping delivery', [
+        'event_id'  => $eventId,
+        'worker_id' => $workerId,
+      ]);
+      return 'lease no longer owned';
     }
 
     $payload = json_decode($row['payload'], true);

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -566,8 +566,13 @@ class Data extends AbstractHelper
     // Without this, rows written during the PR 3 / PR 4 deployment window
     // would carry schema defaults (state='pending', next_attempt_at=NULL)
     // that misrepresent the row in the admin grid and fail PR 4's gate.
+    // store_id is a NOT NULL FK; the pre-PR3 saveRequest never wrote it and
+    // relied on MySQL's silent coercion to 0 (the admin scope). enqueue()
+    // already fixes this for the async path; mirror the fix here so the
+    // synchronous and async writers agree during the PR 3 → PR 4 window.
     $isSuccess = $error === null;
     $event->setData([
+      'store_id'        => (int) ($payload['event']['store']['id'] ?? 0),
       'payload'         => json_encode($payload),
       'status'          => $isSuccess ? 1 : 0,
       'uri'             => $this->getWebhookUrl(),
@@ -598,8 +603,12 @@ class Data extends AbstractHelper
     // Same state-mirror invariant as saveRequest(): the synchronous retry
     // path is one-shot, so both outcomes are terminal in the new state model.
     // retry_count is incremented to reflect the additional attempt.
+    // Re-assert store_id from the payload so a row originally written under
+    // the pre-PR3 buggy path (which omitted store_id and got an implicit 0)
+    // is corrected on retry.
     $isSuccess = $error === null;
     $event->addData([
+      'store_id'        => (int) ($payload['event']['store']['id'] ?? 0),
       'payload'         => json_encode($payload),
       'status'          => $isSuccess ? 1 : 0,
       'uri'             => $this->getWebhookUrl(),

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -363,9 +363,10 @@ class Data extends AbstractHelper
    *
    * @param int    $eventId
    * @param string $workerId  (unused by HTTP layer, reserved for future tracing)
-   * @return bool  true on HTTP 200, false on any error
+   * @return string|null  null on HTTP 200; otherwise a truncated error message
+   *                      that the caller should persist via recordFailedAttempt.
    */
-  public function deliverEvent(int $eventId, string $workerId): bool
+  public function deliverEvent(int $eventId, string $workerId): ?string
   {
     $connection = $this->_resourceConnection->getConnection();
     $tableName  = $this->_resourceConnection->getTableName('kustomer_webhook_integration_events');
@@ -376,25 +377,26 @@ class Data extends AbstractHelper
 
     if (!$row) {
       $this->logger->error('deliverEvent: event row not found', ['event_id' => $eventId]);
-      return false;
+      return 'event row not found';
     }
 
     $payload = json_decode($row['payload'], true);
     if ($payload === null) {
       $this->logger->error('deliverEvent: failed to decode payload', ['event_id' => $eventId]);
-      return false;
+      return 'failed to decode payload';
     }
 
     try {
       $this->performHttpDelivery($payload);
-      return true;
+      return null;
     } catch (\Exception $e) {
+      $errorMsg = substr($e->getMessage(), 0, 200);
       $this->logger->error('deliverEvent: HTTP delivery failed', [
         'event_id'   => $eventId,
         'error_class' => get_class($e),
-        'error'      => substr($e->getMessage(), 0, 200),
+        'error'      => $errorMsg,
       ]);
-      return false;
+      return $errorMsg;
     }
   }
 
@@ -549,12 +551,23 @@ class Data extends AbstractHelper
     // Create a new event model
     $event = $this->eventFactory->create();
 
-    // Set the event data
+    // Populate the new state-machine columns alongside the legacy status.
+    // The synchronous send path makes a single attempt with no auto-retry,
+    // so the outcome is always terminal: success → 'succeeded', failure →
+    // 'failed' with next_attempt_at NULL (which is how the new admin Retry
+    // gate identifies terminal-failed rows eligible for manual requeue).
+    // Without this, rows written during the PR 3 / PR 4 deployment window
+    // would carry schema defaults (state='pending', next_attempt_at=NULL)
+    // that misrepresent the row in the admin grid and fail PR 4's gate.
+    $isSuccess = $error === null;
     $event->setData([
-      'payload' => json_encode($payload),
-      'status' => $error !== null ? 0 : 1,
-      'uri' => $this->getWebhookUrl(),
-      'error' => $error,
+      'payload'         => json_encode($payload),
+      'status'          => $isSuccess ? 1 : 0,
+      'uri'             => $this->getWebhookUrl(),
+      'error'           => $error,
+      'state'           => $isSuccess ? 'succeeded' : 'failed',
+      'retry_count'     => $isSuccess ? 0 : 1,
+      'next_attempt_at' => null,
     ]);
 
     // Save the event
@@ -575,13 +588,19 @@ class Data extends AbstractHelper
     // Load the event
     $event = $this->eventFactory->create()->load($eventId);
 
-    // Update the event data
+    // Same state-mirror invariant as saveRequest(): the synchronous retry
+    // path is one-shot, so both outcomes are terminal in the new state model.
+    // retry_count is incremented to reflect the additional attempt.
+    $isSuccess = $error === null;
     $event->addData([
-      'payload' => json_encode($payload),
-      'status' => $error !== null ? 0 : 1,
-      'uri' => $this->getWebhookUrl(),
-      'error' => $error,
-      'last_sent_at' => date('Y-m-d H:i:s', time()),
+      'payload'         => json_encode($payload),
+      'status'          => $isSuccess ? 1 : 0,
+      'uri'             => $this->getWebhookUrl(),
+      'error'           => $error,
+      'last_sent_at'    => date('Y-m-d H:i:s', time()),
+      'state'           => $isSuccess ? 'succeeded' : 'failed',
+      'retry_count'     => (int)$event->getData('retry_count') + 1,
+      'next_attempt_at' => null,
     ]);
 
     // Update the event

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -309,7 +309,17 @@ class Data extends AbstractHelper
       $connection = $this->_resourceConnection->getConnection();
       $tableName  = $this->_resourceConnection->getTableName('kustomer_webhook_integration_events');
 
+      // Precondition: caller must populate $payload['event']['store'] via
+      // getStoreData() before enqueue (mirrors today's send() behavior).
+      // store_id is a NOT NULL FK to store.store_id; an unset/zero value
+      // would surface as an FK violation and silently route to the
+      // fail-open log. Fail loudly here so the bug is in the caller.
       $storeId = (int) ($payload['event']['store']['id'] ?? 0);
+      if ($storeId <= 0) {
+        throw new \InvalidArgumentException(
+          'enqueue: payload missing event.store.id; caller must populate store data'
+        );
+      }
 
       $connection->insert($tableName, [
         'store_id'       => $storeId,
@@ -456,8 +466,11 @@ class Data extends AbstractHelper
       $data['next_attempt_at'] = null;
     } else {
       // Retryable: schedule next attempt per the backoff ladder.
+      // newRetryCount is the post-increment count (1 after first failure),
+      // so the ladder is indexed by (newRetryCount - 1) to use ladder[0]
+      // for the wait between attempt 1 and attempt 2.
       $backoffSeconds = self::$backoffLadder[
-        min($newRetryCount, count(self::$backoffLadder) - 1)
+        min($newRetryCount - 1, count(self::$backoffLadder) - 1)
       ];
       $data['next_attempt_at'] = new \Zend_Db_Expr(
         'DATE_ADD(NOW(), INTERVAL ' . (int)$backoffSeconds . ' SECOND)'
@@ -475,15 +488,20 @@ class Data extends AbstractHelper
    * Resets state to 'pending' with retry_count=0, mirroring a fresh enqueue.
    * The row is immediately eligible because next_attempt_at = NOW().
    *
+   * Guarded by a conditional predicate so a double-clicked admin button
+   * (or any caller that races with the cron consumer) cannot yank an
+   * in-flight row out from under a worker. Only terminally-failed rows
+   * are eligible, matching the gate in the admin Retry controller.
+   *
    * @param int $eventId
-   * @return void
+   * @return bool true if a row was reset, false if it was not terminal-failed.
    */
-  public function requeueForRetry(int $eventId): void
+  public function requeueForRetry(int $eventId): bool
   {
     $connection = $this->_resourceConnection->getConnection();
     $tableName  = $this->_resourceConnection->getTableName('kustomer_webhook_integration_events');
 
-    $connection->update(
+    $affected = $connection->update(
       $tableName,
       [
         'state'           => 'pending',
@@ -494,8 +512,14 @@ class Data extends AbstractHelper
         'locked_until'    => null,
         'error'           => null,
       ],
-      ['event_id = ?' => $eventId]
+      [
+        'event_id = ?'      => $eventId,
+        'state = ?'         => 'failed',
+        'next_attempt_at IS NULL',
+      ]
     );
+
+    return $affected > 0;
   }
 
   // -------------------------------------------------------------------------

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -19,21 +19,24 @@ class Data extends AbstractHelper
   /**
    * Number of retries permitted after the initial delivery attempt. With
    * MAX_RETRIES=4 a row is attempted up to 5 times (initial + 4 retries):
-   *   attempt 1 (retry_count=0 -> 1, schedule using ladder[0] = 60s)
-   *   attempt 2 (retry_count=1 -> 2, schedule using ladder[1] = 300s)
-   *   attempt 3 (retry_count=2 -> 3, schedule using ladder[2] = 1800s)
-   *   attempt 4 (retry_count=3 -> 4, schedule using ladder[3] = 7200s)
+   *   attempt 1 (retry_count=0 -> 1, schedule using ladder[0] = 30s)
+   *   attempt 2 (retry_count=1 -> 2, schedule using ladder[1] = 120s)
+   *   attempt 3 (retry_count=2 -> 3, schedule using ladder[2] = 300s)
+   *   attempt 4 (retry_count=3 -> 4, schedule using ladder[3] = 600s)
    *   attempt 5 (retry_count=4 -> 5, terminal: next_attempt_at = NULL)
-   * Terminal transition fires when newRetryCount > MAX_RETRIES.
+   * Total delivery budget across all 5 attempts is ~17 minutes before a
+   * row becomes terminally failed and surfaces in the admin grid for
+   * manual review. Terminal transition fires when newRetryCount > MAX_RETRIES.
    */
   const MAX_RETRIES = 4;
 
   /**
    * Backoff ladder in seconds, indexed by (newRetryCount - 1) so the first
-   * retry uses 60s. Entries: 1m, 5m, 30m, 2h. Out-of-range index clamps to
+   * retry uses 30s. Entries: 30s, 2m, 5m, 10m — keeps individual waits
+   * inside common admin-attention windows. Out-of-range index clamps to
    * the last value (defensive — should not happen given the terminal guard).
    */
-  private static $backoffLadder = [60, 300, 1800, 7200];
+  private static $backoffLadder = [30, 120, 300, 600];
 
   /**
    * @var FileFactory

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -17,6 +17,19 @@ use Magento\Sales\Api\OrderRepositoryInterface;
 class Data extends AbstractHelper
 {
   /**
+   * Maximum number of delivery attempts before a row transitions to terminal_failed.
+   * Attempt 1 sets retry_count=1, ..., attempt MAX_RETRIES sets retry_count=MAX_RETRIES
+   * which triggers terminal_failed on the next recordFailedAttempt call.
+   */
+  const MAX_RETRIES = 4;
+
+  /**
+   * Backoff ladder in seconds, indexed by new retry_count after increment.
+   * [1m, 5m, 30m, 2h]. Out-of-range index clamps to last value.
+   */
+  private static $backoffLadder = [60, 300, 1800, 7200];
+
+  /**
    * @var FileFactory
    */
   protected $_fileFactory;
@@ -46,6 +59,11 @@ class Data extends AbstractHelper
    */
   protected $_orderRepository;
 
+  /**
+   * @var \Magento\Framework\App\ResourceConnection
+   */
+  protected $_resourceConnection;
+
   public function __construct(
     Context $context,
     EventFactory $eventFactory,
@@ -54,7 +72,8 @@ class Data extends AbstractHelper
     File $file,
     AddressRepositoryInterface $addressRepository,
     CustomerRepositoryInterface $customerRepository,
-    OrderRepositoryInterface $orderRepository
+    OrderRepositoryInterface $orderRepository,
+    \Magento\Framework\App\ResourceConnection $resourceConnection = null
   ) {
     parent::__construct($context);
 
@@ -66,6 +85,10 @@ class Data extends AbstractHelper
     $this->_addressRepository = $addressRepository;
     $this->_customerRepository = $customerRepository;
     $this->_orderRepository = $orderRepository;
+    // ResourceConnection provides raw DB access needed for atomic queue operations.
+    // Default argument allows the existing constructor signature to remain compatible.
+    $this->_resourceConnection = $resourceConnection
+      ?: ObjectManager::getInstance()->get(\Magento\Framework\App\ResourceConnection::class);
   }
 
   /**
@@ -252,6 +275,244 @@ class Data extends AbstractHelper
 
     // Return the response
     return json_decode($response, true);
+  }
+
+  // -------------------------------------------------------------------------
+  // Queue helpers (added in PR 3 — used by cron consumer; not yet called by
+  // send() or retry(), which remain synchronous until PR 4).
+  // -------------------------------------------------------------------------
+
+  /**
+   * Map a state string to the legacy status integer mirror.
+   *
+   * @param string $state
+   * @return int
+   */
+  public function stateToStatus(string $state): int
+  {
+    return $state === 'succeeded' ? 1 : 0;
+  }
+
+  /**
+   * Enqueue a webhook payload as a new pending row.
+   *
+   * Fail-open: if the INSERT fails, a structured error is written to
+   * var/log/kustomer_webhook_enqueue_failure.log and the exception is
+   * swallowed so the merchant's commerce action is not blocked.
+   *
+   * @param array $payload
+   * @return void
+   */
+  public function enqueue(array $payload): void
+  {
+    try {
+      $connection = $this->_resourceConnection->getConnection();
+      $tableName  = $this->_resourceConnection->getTableName('kustomer_webhook_integration_events');
+
+      $storeId = (int) ($payload['event']['store']['id'] ?? 0);
+
+      $connection->insert($tableName, [
+        'store_id'       => $storeId,
+        'payload'        => json_encode($payload, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE),
+        'status'         => 0,
+        'uri'            => $this->getWebhookUrl(),
+        'state'          => 'pending',
+        'retry_count'    => 0,
+        'next_attempt_at'=> new \Zend_Db_Expr('NOW()'),
+        'locked_until'   => null,
+        'locked_by'      => null,
+      ]);
+    } catch (\Exception $e) {
+      // Fail open: do not rethrow. Write structured error to dedicated log file.
+      $eventType  = $payload['event']['type']  ?? 'unknown';
+      $eventName  = $payload['event']['name']  ?? 'unknown';
+      $storeId    = $payload['event']['store']['id'] ?? null;
+      $errorClass = get_class($e);
+      // Truncate message to 200 chars to avoid leaking sensitive DB details.
+      $errorMsg   = substr($e->getMessage(), 0, 200);
+
+      $entry = json_encode([
+        'timestamp'     => date('c'),
+        'event_type'    => $eventType,
+        'event_name'    => $eventName,
+        'store_id'      => $storeId,
+        'error_class'   => $errorClass,
+        'error_message' => $errorMsg,
+      ], JSON_UNESCAPED_SLASHES);
+
+      $logPath = $this->_directoryList->getPath('var') . '/log/kustomer_webhook_enqueue_failure.log';
+      error_log($entry . PHP_EOL, 3, $logPath);
+    }
+  }
+
+  /**
+   * Deliver a queued event over HTTP.
+   *
+   * Loads the stored payload and performs the HMAC + cURL exchange.
+   * Does NOT touch any state column — that is the caller's responsibility.
+   *
+   * @param int    $eventId
+   * @param string $workerId  (unused by HTTP layer, reserved for future tracing)
+   * @return bool  true on HTTP 200, false on any error
+   */
+  public function deliverEvent(int $eventId, string $workerId): bool
+  {
+    $connection = $this->_resourceConnection->getConnection();
+    $tableName  = $this->_resourceConnection->getTableName('kustomer_webhook_integration_events');
+
+    $row = $connection->fetchRow(
+      $connection->select()->from($tableName)->where('event_id = ?', $eventId)
+    );
+
+    if (!$row) {
+      $this->logger->error('deliverEvent: event row not found', ['event_id' => $eventId]);
+      return false;
+    }
+
+    $payload = json_decode($row['payload'], true);
+    if ($payload === null) {
+      $this->logger->error('deliverEvent: failed to decode payload', ['event_id' => $eventId]);
+      return false;
+    }
+
+    try {
+      $this->performHttpDelivery($payload);
+      return true;
+    } catch (\Exception $e) {
+      $this->logger->error('deliverEvent: HTTP delivery failed', [
+        'event_id'   => $eventId,
+        'error_class' => get_class($e),
+        'error'      => substr($e->getMessage(), 0, 200),
+      ]);
+      return false;
+    }
+  }
+
+  /**
+   * Transition a processing row back to 'failed'.
+   *
+   * Mirrors o-webhooks-worker convention: there is a single 'failed' state.
+   * Terminal vs retryable is encoded by next_attempt_at:
+   *   - retry_count >= MAX_RETRIES  → next_attempt_at = NULL (terminal)
+   *   - else                        → next_attempt_at = NOW() + backoff (retryable)
+   *
+   * Uses a conditional UPDATE with locked_by = $expectedLockedBy so that
+   * a stale worker cannot overwrite a row already reclaimed by another worker.
+   *
+   * @param int    $eventId
+   * @param string $error             Short error description (no PII).
+   * @param string $expectedLockedBy  Worker UUID that owns the lease.
+   * @param bool   $requireExpiredLease  If true, also requires locked_until <= NOW().
+   * @return bool  true if a row was updated, false if another worker already transitioned it.
+   */
+  public function recordFailedAttempt(
+    int $eventId,
+    string $error,
+    string $expectedLockedBy,
+    bool $requireExpiredLease = false
+  ): bool {
+    $connection = $this->_resourceConnection->getConnection();
+    $tableName  = $this->_resourceConnection->getTableName('kustomer_webhook_integration_events');
+
+    // Read current retry_count.
+    $row = $connection->fetchRow(
+      $connection->select()
+        ->from($tableName, ['retry_count'])
+        ->where('event_id = ?', $eventId)
+        ->where('state = ?', 'processing')
+        ->where('locked_by = ?', $expectedLockedBy)
+    );
+
+    if (!$row) {
+      // Another worker already transitioned this row.
+      return false;
+    }
+
+    $newRetryCount = (int)$row['retry_count'] + 1;
+
+    // Build WHERE conditions as strings (bound separately) to avoid ambiguity
+    // with Magento's update() array-where handling for non-placeholder entries.
+    $whereConditions = [
+      $connection->quoteInto('event_id = ?', $eventId),
+      $connection->quoteInto('state = ?', 'processing'),
+      $connection->quoteInto('locked_by = ?', $expectedLockedBy),
+    ];
+    if ($requireExpiredLease) {
+      $whereConditions[] = 'locked_until <= NOW()';
+    }
+    $whereSql = implode(' AND ', $whereConditions);
+
+    $data = [
+      'state'       => 'failed',
+      'status'      => $this->stateToStatus('failed'),
+      'retry_count' => $newRetryCount,
+      'error'       => substr($error, 0, 200),
+      'locked_by'   => null,
+      'locked_until'=> null,
+    ];
+
+    if ($newRetryCount >= self::MAX_RETRIES) {
+      // Terminal: NULL next_attempt_at signals "won't retry."
+      $data['next_attempt_at'] = null;
+    } else {
+      // Retryable: schedule next attempt per the backoff ladder.
+      $backoffSeconds = self::$backoffLadder[
+        min($newRetryCount, count(self::$backoffLadder) - 1)
+      ];
+      $data['next_attempt_at'] = new \Zend_Db_Expr(
+        'DATE_ADD(NOW(), INTERVAL ' . (int)$backoffSeconds . ' SECOND)'
+      );
+    }
+
+    $affected = $connection->update($tableName, $data, $whereSql);
+    return $affected > 0;
+  }
+
+  /**
+   * Reset a terminal row so the cron consumer will re-attempt delivery.
+   * Called by the admin Retry action in PR 4. Not yet invoked in PR 3.
+   *
+   * Resets state to 'pending' with retry_count=0, mirroring a fresh enqueue.
+   * The row is immediately eligible because next_attempt_at = NOW().
+   *
+   * @param int $eventId
+   * @return void
+   */
+  public function requeueForRetry(int $eventId): void
+  {
+    $connection = $this->_resourceConnection->getConnection();
+    $tableName  = $this->_resourceConnection->getTableName('kustomer_webhook_integration_events');
+
+    $connection->update(
+      $tableName,
+      [
+        'state'           => 'pending',
+        'status'          => 0,
+        'retry_count'     => 0,
+        'next_attempt_at' => new \Zend_Db_Expr('NOW()'),
+        'locked_by'       => null,
+        'locked_until'    => null,
+        'error'           => null,
+      ],
+      ['event_id = ?' => $eventId]
+    );
+  }
+
+  // -------------------------------------------------------------------------
+  // Internal HTTP delivery — shared by deliverEvent() and the legacy send()/retry()
+  // -------------------------------------------------------------------------
+
+  /**
+   * Perform the HMAC-signed cURL POST to the Kustomer webhook endpoint.
+   * Throws on non-200 or cURL error. Does not write any DB rows.
+   *
+   * @param array $payload
+   * @return mixed  Decoded JSON response body.
+   * @throws \Exception
+   */
+  private function performHttpDelivery(array $payload)
+  {
+    return $this->sendApiRequest($payload);
   }
 
   /**

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -270,9 +270,18 @@ class Data extends AbstractHelper
 
       $statusCode = (int) curl_getinfo($curl, CURLINFO_HTTP_CODE);
 
-      // If there's an error, log and throw an exception
+      // If there's an error, log and throw an exception.
+      // The exception message intentionally omits the response body because
+      // it ends up persisted in kustomer_webhook_integration_events.error
+      // (and exported via Helper\Data::export()) and could embed anything
+      // Kustomer returned — internal diagnostic strings, request ids, etc.
+      // The full body is captured in app logs for ephemeral debugging.
       if ($statusCode !== 200) {
-        throw new \Exception(sprintf('HTTP %d: %s', $statusCode, $response));
+        $this->logger->error('Kustomer webhook returned non-200', [
+          'status_code'   => $statusCode,
+          'response_body' => substr((string)$response, 0, 1000),
+        ]);
+        throw new \Exception(sprintf('HTTP %d', $statusCode));
       }
     } finally {
       // Always close the cURL session handle
@@ -297,6 +306,36 @@ class Data extends AbstractHelper
   public function stateToStatus(string $state): int
   {
     return $state === 'succeeded' ? 1 : 0;
+  }
+
+  /**
+   * Normalize an error string before it gets persisted to the
+   * kustomer_webhook_integration_events.error column. The column is
+   * surfaced via the admin grid and Helper\Data::export(), so any
+   * upstream error message that may contain control characters,
+   * embedded newlines, or other operator-unfriendly content is reduced
+   * to a single printable line capped at 200 characters.
+   *
+   * Upstream exception messages already strip response bodies at the
+   * source (see sendApiRequest()), so the typical input here is a
+   * libcurl error description or a short status code. This is a
+   * defense-in-depth pass for anything that slips through.
+   *
+   * @param string|null $error
+   * @return string|null
+   */
+  private function sanitizeErrorForPersistence($error): ?string
+  {
+    if ($error === null || $error === '') {
+      return $error;
+    }
+    // Replace ASCII control chars (newlines, tabs, NUL, DEL, etc.) with a
+    // single space, then collapse whitespace runs and trim. Truncate to
+    // 200 chars to match the prior substr bound and avoid blowing the
+    // column out.
+    $clean = preg_replace('/[\x00-\x1F\x7F]+/', ' ', (string)$error) ?? '';
+    $clean = preg_replace('/\s+/', ' ', $clean) ?? '';
+    return substr(trim($clean), 0, 200);
   }
 
   /**
@@ -494,7 +533,7 @@ class Data extends AbstractHelper
       'state'       => 'failed',
       'status'      => $this->stateToStatus('failed'),
       'retry_count' => $newRetryCount,
-      'error'       => substr($error, 0, 200),
+      'error'       => $this->sanitizeErrorForPersistence($error),
       'locked_by'   => null,
       'locked_until'=> null,
     ];

--- a/etc/crontab.xml
+++ b/etc/crontab.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Cron:etc/crontab.xsd">
+  <group id="default">
+    <job name="kustomer_webhook_integration_process_queue"
+         instance="Kustomer\WebhookIntegration\Cron\ProcessQueue"
+         method="execute">
+      <schedule>* * * * *</schedule>
+    </job>
+  </group>
+</config>


### PR DESCRIPTION
# User description
Linear: https://linear.app/kustomer/issue/PROD-98

## What this PR does

Adds the **plumbing** for asynchronous webhook delivery: five new helper methods on `Helper\Data` and a new `Cron\ProcessQueue` consumer wired to run every minute. **No merchant-visible behavior change.** `send()` and `retry()` are byte-for-byte unchanged in this PR — the cron runs against an empty queue until PR 4 flips the switch.

This is PR 3 of 4 in the PROD-98 series. PRs 1 and 2 are merged.

| PR | Title | Status |
|---|---|---|
| [#9](https://github.com/kustomer/adobe_commerce_extension/pull/9) | PR 1: Logging hygiene | Merged |
| [#10](https://github.com/kustomer/adobe_commerce_extension/pull/10) | PR 2: Schema migration (additive, dormant) | Merged |
| **this PR** | **PR 3: State-machine plumbing & cron consumer (dormant)** | **This PR** |
| next | PR 4: Flip the switch — `send()` enqueues, admin retry gates | Pending |

## State machine (aligned with `o-webhooks-worker`)

| State | Meaning |
|---|---|
| `pending` | Enqueued by `send()`, not yet picked up |
| `processing` | Claimed by a cron worker (lease) |
| `succeeded` | Delivered (terminal; `next_attempt_at` NULL) |
| `failed` | Delivery failed. Retryable-vs-terminal encoded by `next_attempt_at`: non-NULL future timestamp = will retry; NULL = won't retry (`retry_count > MAX_RETRIES`) |

This matches `dev-monorepo/js/o-webhooks-worker` (`service/transaction_service.js`) — `succeeded` and `failed` are the only terminal state strings; `nextRetry`/`next_attempt_at` carries the retry decision.

## Data flow

### Synchronous (today — `dev-main`, `send()` unchanged in this PR)

```
┌────────────────┐
│  Customer hits │
│  Checkout      │
└────────┬───────┘
         │ POST /checkout
         ▼
┌──────────────────────────────────────────────────────┐
│ Magento PHP-FPM worker (request thread)              │
│                                                      │
│  Observer::execute()                                 │
│    └─► Helper::send($payload)                        │
│         ├─► sendApiRequest()  ───────────────┐       │
│         │   curl_exec, 10s timeout           │       │
│         │                                    ▼       │
│         │                       ┌──────────────────┐ │
│         │   ◄───── 200 / 5xx ───┤  Kustomer        │ │
│         │                       │  /hooks/...      │ │
│         │                       └──────────────────┘ │
│         └─► saveRequest() ───► events table          │
│                                                      │
│  Return 200 OK to customer                           │
└──────────────────────────────────────────────────────┘
         ▲
         │ Customer waits for ALL of this.
         │ If Kustomer is slow → customer's checkout hangs.
         │ If 10s timeout fires → customer waited 10s for nothing.
```

### Asynchronous (after PR 4 — what this PR's plumbing enables)

```
═══ HOT PATH (customer-facing) ═══════════════════════════════════

┌────────────────┐
│  Customer hits │
│  Checkout      │
└────────┬───────┘
         │ POST /checkout
         ▼
┌──────────────────────────────────────────────────────┐
│ Magento PHP-FPM worker (request thread)              │
│                                                      │
│  Observer::execute()                                 │
│    └─► Helper::send($payload)                        │
│         └─► enqueue()                                │
│              └─► INSERT INTO events                  │
│                  (state='pending',                   │
│                   next_attempt_at=NOW())             │
│                                                      │
│  Return 200 OK to customer  (target: <1s)            │
└──────────────────────────────────────────────────────┘
         │
         │ Customer's part is done.
         ▼
                          ┌─────────────────┐
                          │  events table   │
                          │  ┌─────────────┐│
                          │  │ id=42       ││
                          │  │ state=      ││
                          │  │   pending   ││
                          │  │ next_attempt││
                          │  │ retry_count ││
                          │  │ locked_by   ││
                          │  │ locked_until││
                          │  └─────────────┘│
                          └────────┬────────┘
                                   │ polled
                                   ▼
═══ COLD PATH (cron worker, every 1 min) ════════════════════════

┌─────────────────────────────────────────────────────┐
│ bin/magento cron:run                                │
│   └─► Cron\ProcessQueue::execute()                  │
│                                                     │
│  ① recoverExpiredLeases()                           │
│     SELECT WHERE state='processing'                 │
│       AND locked_until <= NOW()                     │
│     → recordFailedAttempt(...lease expired)         │
│                                                     │
│  ② claimBatch()                                     │
│     UPDATE state='processing',                      │
│            locked_by=:wid,                          │
│            locked_until=NOW()+5m                    │
│     WHERE state IN ('pending','failed')             │
│       AND next_attempt_at <= NOW()                  │
│     LIMIT 10                                        │
│                                                     │
│  ③ for each claimed row:                            │
│     deliverEvent($id, $wid) ──── curl ───┐          │
│       ▲                                  │          │
│       │ re-fetch with lease guard        │          │
│       └──────────────────────────────────┘          │
│                                          │          │
│     ┌──── null (success) ─────┐          │          │
│     │                         │          ▼          │
│     │  UPDATE state=          │  ┌──────────────┐   │
│     │    'succeeded'          │  │  Kustomer    │   │
│     │  WHERE locked_by=:wid   │  │ /hooks/...   │   │
│     │                         │  └──────────────┘   │
│     │                         │                     │
│     └── error string ─────────┘                     │
│        recordFailedAttempt()                        │
│          retry_count++                              │
│          if > MAX_RETRIES:                          │
│            next_attempt_at = NULL  (terminal)       │
│          else:                                      │
│            next_attempt_at = NOW()                  │
│              + ladder[retry_count-1]                │
│              (30s, 2m, 5m, 10m)                     │
└─────────────────────────────────────────────────────┘
```

### Per-row state transitions

```
                  ┌─────────┐
   enqueue() ───► │ pending │ ◄──────────────┐
                  └────┬────┘                │
                       │ claimBatch          │ requeueForRetry()
                       ▼                     │ (admin Retry button)
                  ┌───────────┐              │
                  │processing │              │
                  └──┬─────┬──┘              │
              ok     │     │      fail       │
                     │     │                 │
                     ▼     ▼                 │
              ┌──────────┐ ┌──────────────┐  │
              │succeeded │ │ failed       │  │
              │ (term.)  │ │ next_attempt │  │
              └──────────┘ │   != NULL    │  │
                           │ (retryable)  │  │
                           └──────┬───────┘  │
                                  │ time     │
                                  │ passes   │
                                  └─────────►│
                                             │
                           ┌─────────────────┘
                           │ retry_count > MAX_RETRIES
                           ▼
                    ┌──────────────┐
                    │ failed       │
                    │ next_attempt │   ◄── admin Retry only
                    │   = NULL     │
                    │ (terminal)   │
                    └──────────────┘
```

### Concurrency: two workers, one row

```
Worker A (wid=aaa)              Worker B (wid=bbb)
────────────────────────────────────────────────────
claim UPDATE ─┐
              │
              ▼
   InnoDB locks the row
              │
              │                  claim UPDATE
              │                       │
              │                       │ (blocks)
   row locked_by=aaa                  │
              │                       │
   commits ───┘                       │
                                      ▼
                            re-evaluates predicate:
                            state='processing' now,
                            so row no longer matches
                            'state IN (pending,failed)'
                                      │
                            picks next eligible row
                            or returns empty batch
```

Every subsequent UPDATE — success, failure, lease recovery — also predicates on `locked_by = :wid`, so even if a worker mistakenly thinks it still owns a row (e.g. its lease expired in flight and another worker recovered it), only the actual owner's writes ever land.

## Changes

### `Helper/Data.php` — five new public methods

1. **`stateToStatus(string $state): int`** — pure mapping: `succeeded` → 1, every other state → 0. Used by every code path that writes `state` so the legacy `status` column stays consistent.
2. **`enqueue(array $payload): void`** — writes a row with `state='pending'`, `next_attempt_at=NOW()`, `status=0`, `store_id` populated explicitly from `$payload['event']['store']['id']` (latent bug fix: today's `saveRequest` never writes `store_id`, relying on MySQL implicit 0). Throws `InvalidArgumentException` if the precondition is missing; on DB exception it **fails open** — `error_log()` to `var/log/kustomer_webhook_enqueue_failure.log` with stable fields, do not rethrow. **Not yet called by `send()`** — that happens in PR 4.
3. **`deliverEvent(int $eventId, string $workerId): ?string`** — HTTP-only delivery. Re-fetches the row with a lease guard (`state='processing' AND locked_by=$workerId AND locked_until > NOW()`) so a worker whose lease was revoked mid-tick cannot fire a duplicate cURL. Posts to Kustomer; returns `null` on success or a truncated, sanitized error string on failure. Does NOT touch any state columns — cron orchestration owns those.
4. **`recordFailedAttempt(int $eventId, string $error, string $expectedLockedBy, bool $requireExpiredLease = false): bool`** — single failure-transition path used by both normal failures and lease-expiry recovery. Conditional UPDATE always predicates on `state='processing' AND locked_by=:expectedLockedBy`; with `$requireExpiredLease=true`, also requires `locked_until <= NOW()`. Increments `retry_count`, computes `next_attempt_at` from the backoff ladder, decides terminal vs retryable, mirrors `status` via `stateToStatus()`, clears the lease. Error is run through `sanitizeErrorForPersistence()` (strips control chars, collapses whitespace, caps at 200) before being written.
5. **`requeueForRetry(int $eventId): bool`** — sets `state='pending'`, `retry_count=0`, `next_attempt_at=NOW()`, clears lease and error. Conditional on `state='failed' AND next_attempt_at IS NULL` so a double-clicked admin Retry cannot yank an in-flight row out from under a worker. Mirrors a fresh enqueue. **Not called yet** — `Retry::execute()` is unchanged in this PR.

`retry_count` semantics: counts failed attempts already consumed. With `MAX_RETRIES=4`, a row gets up to 5 total delivery attempts (initial + 4 retries) before going terminal. Backoff ladder: **30s → 2m → 5m → 10m** (total delivery budget ~17 minutes before manual review).

### `Cron/ProcessQueue.php` — new cron consumer

Each minute:

1. **Recover crashed rows** — `SELECT WHERE state='processing' AND locked_until <= NOW()` (capped at `BATCH_SIZE`); for each, call `recordFailedAttempt(..., requireExpiredLease: true)`. A deploy-induced burst rolls over to subsequent ticks rather than chewing up one cron run.
2. **Atomic claim** (MySQL):
   ```sql
   UPDATE kustomer_webhook_integration_events
   SET state='processing',
       status=0,
       locked_until=DATE_ADD(NOW(), INTERVAL 5 MINUTE),
       locked_by=:worker_id
   WHERE state IN ('pending', 'failed')
     AND next_attempt_at IS NOT NULL
     AND next_attempt_at <= NOW()
   ORDER BY created_at ASC
   LIMIT :batch_size;
   ```
   The `IS NOT NULL` predicate naturally excludes terminal failures. `:worker_id` is 128 bits of `random_bytes` per cron run (not host/PID — coexists cleanly with overlapping runs).
3. **For each claimed row** — call `deliverEvent()` (which itself re-verifies the lease before the cURL).
4. **On success** — conditional UPDATE: `state='succeeded', status=1, last_sent_at=NOW(), error=NULL` predicated on `state='processing' AND locked_by=:worker_id`. 0-row outcome means a stale worker; log + skip rather than overwrite.
5. **On failure** — `recordFailedAttempt(..., requireExpiredLease: false)` with the actual error message threaded through from `deliverEvent()`.

### `etc/crontab.xml` — new file

Wires `Cron\ProcessQueue::execute` to run every minute. No `etc/di.xml` change needed — Magento auto-wires all constructor dependencies (helper, `ResourceConnection`, `LoggerInterface`).

## Why this PR is safe alone

- `Observer/{Order,Customer,Address,OrderAddress}.php` — unchanged.
- `Helper\Data::send()` and `Helper\Data::retry()` — production behavior unchanged. Synchronous curl still happens on the request thread. (The underlying `saveRequest()` / `updateRequest()` writers now also populate the new state columns so rows written during the PR 3 → PR 4 deployment window are well-formed under the new invariant.)
- `Controller/Adminhtml/Event/Retry.php` — unchanged.
- New helpers exist but have no callers in production code paths.
- Cron job runs but finds zero `pending` rows (because nothing enqueues), exits cleanly.

The cron consumer can be exercised end-to-end by inserting a `pending` row via direct SQL — useful for staging verification — but no normal traffic flows through it.

## How merchants pick this up

No action required for this PR. After PR 4 merges and a new Packagist release ships, the merchant deploy is:

```sh
composer update kustomer/webhook-integration
php bin/magento setup:upgrade
php bin/magento setup:di:compile
php bin/magento setup:static-content:deploy -f --area=adminhtml en_US
php bin/magento cache:flush
```

with the caveat that **Magento cron must be running** for delivery to happen at all. We'll surface this in the release notes alongside PR 4.

## Verification

This PR is dormant in production paths — all new code is reachable only via cron, which finds zero `pending` rows because nothing enqueues yet. Exercising the consumer in isolation requires staging rows via direct SQL, which is throw-away setup compared to running the same scenarios end-to-end once PR 4 flips `send()`.

**Staging verification for PR 3 is intentionally deferred to PR 4's e2e plan**, which exercises the same code paths (enqueue → cron tick → succeed/fail → retry ladder → terminal → admin Retry) against real traffic on a Cloudways staging instance.

The static guarantees that make this PR safe to merge dormant:

- `Observer/*` and `Controller/Adminhtml/Event/Retry.php` are unchanged.
- `send()` and `retry()` still hit `sendApiRequest` synchronously — production behavior is preserved.
- `etc/crontab.xml` adds one new job; with an empty queue the consumer's first action is a SELECT that returns zero rows, then it exits.

## Out of scope for this PR

- Flipping `send()` to enqueue mode (PR 4).
- Tightening `Retry::execute()` gating (PR 4).
- `composer.json` version bump (PR 4, so the new Packagist release coincides with the actual behavior change).
- `system.xml` sync/deferred toggle, admin grid styling for async states, TTL/cleanup cron — deferred per plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Add state-machine plumbing in <code>Helper\Data</code> to enqueue events, deliver them, and record retries while keeping synchronous <code>send()</code> behavior unchanged until the next flip. Schedule <code>Cron\ProcessQueue</code> via the new cron job so it can claim pending rows, recover expired leases, and persist delivery outcomes once the async path is enabled.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/kustomer/adobe_commerce_extension/12?tool=ast&topic=Queue+helpers>Queue helpers</a>
        </td><td>Add queue helpers to <code>Helper\Data</code> that map states, sanitize errors, enqueue payloads, deliver with lease guards, track retry backoff, and allow requeues while mirroring the new state columns for the legacy synchronous path.<details><summary>Modified files (1)</summary><ul><li>Helper/Data.php</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>brian.hong@kustomer.com</td><td>PROD-98 PR3: tighten b...</td><td>May 12, 2026</td></tr>
<tr><td>brianhong@users.norepl...</td><td>PROD-98 PR 2/4: add st...</td><td>May 11, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/kustomer/adobe_commerce_extension/12?tool=ast&topic=Cron+runner>Cron runner</a>
        </td><td>Wire <code>Cron\ProcessQueue</code> into cron so it recovers expired leases, atomically claims batches, delivers each event, and records successes or failures against the shared queue before the async flow is live.<details><summary>Modified files (2)</summary><ul><li>Cron/ProcessQueue.php</li>
<li>etc/crontab.xml</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>brian.hong@kustomer.com</td><td>PROD-98 PR3: address r...</td><td>May 11, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/kustomer/adobe_commerce_extension/12?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>